### PR TITLE
Fix issue #16.

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -36,8 +36,8 @@ exports.isAbsolute = function absPath(file) {
 
 
 exports.merge = function marge(src, dest) {
-    // NOTE: Do not merge arrays.
-    if (thing.isObject(src) && !thing.isArray(src) && !thing.isNullOrUndefined(dest)) {
+    // NOTE: Do not merge arrays and only merge objects into objects.
+    if (!thing.isArray(src) && thing.isObject(src) && thing.isObject(dest)) {
 
         Object.getOwnPropertyNames(src).forEach(function(prop) {
             var descriptor;

--- a/test/common.js
+++ b/test/common.js
@@ -58,3 +58,22 @@ test('merge', function (t) {
 
     t.end();
 });
+
+
+test('merge with existing props', function (t) {
+    var src, dest;
+
+    src = {
+        'a': {
+            'foo': false
+        }
+    };
+    dest = { 'a': '[Object object]' };
+
+    t.doesNotThrow(function () {
+        common.merge(src, dest);
+        t.deepEqual(src.a, dest.a);
+    });
+
+    t.end();
+});


### PR DESCRIPTION
Issue #16 (and PM2) exposed a bug wherein if we attempted to merge objects with properties of the same name but different types (in this case merging and object into a string) it would fail. This PR ensures we only merge object into objects, overwriting where there's a conflict. Test case included.

The pm2 scenario is also a bug wherein pm2 adds an `env` property to `process.env` containing the original `process.env` values. As a result (and since all environment variables are strings), the result value of process.env.env is the string `[Object object]`, which is a bug.
