### PR TITLE
exporting config function as module.export.config

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,3 +289,5 @@ module.exports = function confit(options) {
 
     return factory;
 };
+
+module.exports.config = config;


### PR DESCRIPTION
To normalize config API's, I have a requirement where given a JSON data create confit config object. So exporting [config](https://github.com/krakenjs/confit/blob/master/index.js#L30) function as `module.export.config`.
