### PR TITLE
handler.file and glob are factory functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ var handlers = require('shortstop-handlers');
 var options = {
     basedir: path.join(__dirname, 'config');
     protocols: {
-        file: handlers.file,
-        glob: handlers.glob
+        file: handlers.file(basedir, options),
+        glob: handlers.glob(options)
     }
 };
 


### PR DESCRIPTION
If you just put handler.file / glob etc in as the protocol you end up with a whole bunch of stringified functions in your config object (the resolver as opposed to the resolved value)