### PR TITLE
Change order precedence

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -31,7 +31,7 @@
     "boss": false,
     "debug": false,
     "eqnull": true,
-    "esnext": false,
+    "esnext": true,
     "evil": false,
     "expr": false,
     "funcscope": false,

--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ config.get('env:staging');     // false
 config.get('env:production');  // false
 config.get('env:custom');      // true
 ```
+#### Precedence
+
+Precedence takes the following form (lower numbers overwrite higher numbers):
+
+1. command line arguments
+2. env variables
+3. environment-specific config (e.g., `development.json`)
+4. main config (`config.json`)
+5. `env` normalization (`env`, `env:development`, etc)
+
+#### Shortstop Handlers
 
 Confit by default comes with 2 shortstop handlers enabled.
 

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -31,8 +31,6 @@ export default class Factory {
         this.basedir = basedir;
         this.protocols = protocols;
         this.promise = Promise.resolve({})
-            .then(store => Common.merge(Provider.argv(), store))
-            .then(store => Common.merge(Provider.env(), store))
             .then(store => Common.merge(Provider.convenience(), store))
             .then(Factory.conditional(store => {
                 let file = Path.join(this.basedir, defaults);
@@ -41,7 +39,9 @@ export default class Factory {
             .then(Factory.conditional(store => {
                 let file = Path.join(this.basedir, `${store.env.env}.json`);
                 return Common.merge(shush(file), store);
-            }));
+            }))
+            .then(store => Common.merge(Provider.env(), store))
+            .then(store => Common.merge(Provider.argv(), store));
     }
 
     addDefault(obj) {

--- a/test/confit-test.js
+++ b/test/confit-test.js
@@ -452,4 +452,32 @@ test('confit', function (t) {
         t.end();
     });
 
+
+    t.test('precedence', function (t) {
+        var factory;
+        var argv = process.argv;
+        var env = process.env;
+
+        process.argv = [ 'node', __filename, '--override=argv'];
+        process.env = {
+            NODE_ENV: 'development',
+            override: 'env',
+            misc: 'env'
+        };
+
+        factory = confit(path.join(__dirname, 'fixtures', 'defaults'));
+        factory.create(function (err, config) {
+            t.error(err);
+            t.ok(config);
+            t.equal(config.get('override'), 'argv');
+            t.equal(config.get('misc'), 'env');
+            t.end();
+        });
+
+        t.on('end', function () {
+            process.argv = argv;
+            process.env = env;
+        });
+
+    });
 });


### PR DESCRIPTION
This load order seems to make more sense and has come up from time to time (like krakenjs/kraken-js#336).

Previous:
argv -> env -> convenience -> config.json -> [env].json

With this change:
convenience -> config.json -> [env].json -> env -> argv

In other words, environment variables trump `*.json` entries and command line arguments trump all.
