### PR TITLE
Minor es6 cleanup - switch to Object.assign

### DIFF
--- a/lib/factory.js
+++ b/lib/factory.js
@@ -28,8 +28,8 @@ const debug = debuglog('confit');
 export default class Factory {
 
     constructor({ basedir, protocols =  {}, defaults = 'config.json' }) {
-        this.basedir = basedir;
-        this.protocols = protocols;
+        Object.assign(this, { basedir, protocols });
+
         this.promise = Promise.resolve({})
             .then(store => Common.merge(Provider.convenience(), store))
             .then(Factory.conditional(store => {


### PR DESCRIPTION
Just a small cleanup leveraging `Object.assign`.
