### PR TITLE
add JSON parse attempt to reading of env variables

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -47,12 +47,12 @@ export default {
         // process.env is not a normal object, so we
         // need to map values.
         for (let env of Object.keys(process.env)) {
-            result[env] = process.env[env];
             //if variable is stringified JSON, parse it
             try {
                 result[env] = JSON.parse(process.env[env]);
             } catch (err) {
-                //noop
+                //set what we couldn't parse
+                result[env] = process.env[env];
             }
         }
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -48,6 +48,12 @@ export default {
         // need to map values.
         for (let env of Object.keys(process.env)) {
             result[env] = process.env[env];
+            //if variable is stringified JSON, parse it
+            try {
+                result[env] = JSON.parse(process.env[env]);
+            } catch (err) {
+                //noop
+            }
         }
 
         return result;

--- a/test/confit-test.js
+++ b/test/confit-test.js
@@ -318,7 +318,32 @@ test('confit', function (t) {
         });
 
     });
+    t.test('override with stringified JSON env variable', function (t) {
+        var factory;
+        var env = process.env;
 
+        process.env = {
+            NODE_ENV: 'development',
+            override: {
+                'nested': {
+                    'nested': true
+                }
+            }
+        };
+
+        factory = confit(path.join(__dirname, 'fixtures', 'defaults'));
+        factory.create(function (err, config) {
+            t.error(err);
+            t.ok(config);
+            t.equal(config.get('override:nested:nested'), true);
+            t.end();
+        });
+
+        t.on('end', function () {
+            process.env = env;
+        });
+
+    });
 
     t.test('confit addOverride as json object', function (t) {
         var basedir;

--- a/test/confit-test.js
+++ b/test/confit-test.js
@@ -324,11 +324,11 @@ test('confit', function (t) {
 
         process.env = {
             NODE_ENV: 'development',
-            nested: JSON.stringify({
+            nested: {
                 'foo': {
                     'bar': true
                 }
-            })
+            }
         };
 
         factory = confit(path.join(__dirname, 'fixtures', 'defaults'));
@@ -338,35 +338,85 @@ test('confit', function (t) {
             t.equal(config.get('nested:foo:bar'), true);
             t.equal(config.get('NODE_ENV'), 'development');
             t.equal(config.get('nested:foo:jazz'), 'hands');
+            process.env = env;
             t.end();
         });
 
-        t.on('end', function () {
-            process.env = env;
-        });
+
 
     });
 
-    t.test('override with stringified number as env variable', function (t) {
+    t.test('override with string as env variable', function (t) {
         var factory;
         var env = process.env;
 
         process.env = {
-            nested: "8000"
+            override: 'foo'
         };
 
         factory = confit(path.join(__dirname, 'fixtures', 'defaults'));
         factory.create(function (err, config) {
             t.error(err);
             t.ok(config);
-            t.equal(config.get('nested'), 8000);
+            t.equal(config.get('override'), 'foo');
+            process.env = env;
             t.end();
         });
 
-        t.on('end', function () {
+
+    });
+    t.test('override with stringified number as env variable', function (t) {
+        var factory;
+        var env = process.env;
+
+        process.env = {
+            override: '8000'
+        };
+
+        factory = confit(path.join(__dirname, 'fixtures', 'defaults'));
+        factory.create(function (err, config) {
+            t.error(err);
+            t.ok(config);
+            t.equal(config.get('override'), 8000);
             process.env = env;
+            t.end();
         });
 
+
+    });
+    t.test('override with array as env variable', function (t) {
+        var factory;
+        var env = process.env;
+
+        process.env = {
+            override: [1, 2, 3]
+        };
+
+        factory = confit(path.join(__dirname, 'fixtures', 'defaults'));
+        factory.create(function (err, config) {
+            t.error(err);
+            t.ok(config);
+            t.deepEqual(config.get('override'), [1, 2, 3]);
+            process.env = env;
+            t.end();
+        });
+    });
+    t.test('override with function as env variable', function (t) {
+        var factory;
+        var env = process.env;
+
+        process.env = {
+            override: function() { return 'foo'}
+        };
+
+        factory = confit(path.join(__dirname, 'fixtures', 'defaults'));
+        factory.create(function (err, config) {
+            t.error(err);
+            t.ok(config);
+            t.deepEqual(config.get('override')(), 'foo');
+            process.env = env;
+            t.end();
+        });
     });
     t.test('confit addOverride as json object', function (t) {
         var basedir;

--- a/test/confit-test.js
+++ b/test/confit-test.js
@@ -324,9 +324,9 @@ test('confit', function (t) {
 
         process.env = {
             NODE_ENV: 'development',
-            override: {
-                'nested': {
-                    'nested': true
+            nested: {
+                'foo': {
+                    'bar': true
                 }
             }
         };
@@ -335,7 +335,8 @@ test('confit', function (t) {
         factory.create(function (err, config) {
             t.error(err);
             t.ok(config);
-            t.equal(config.get('override:nested:nested'), true);
+            t.equal(config.get('nested:foo:bar'), true);
+            t.equal(config.get('nested:foo:jazz'), 'hands');
             t.end();
         });
 

--- a/test/confit-test.js
+++ b/test/confit-test.js
@@ -324,11 +324,11 @@ test('confit', function (t) {
 
         process.env = {
             NODE_ENV: 'development',
-            nested: {
+            nested: JSON.stringify({
                 'foo': {
                     'bar': true
                 }
-            }
+            })
         };
 
         factory = confit(path.join(__dirname, 'fixtures', 'defaults'));
@@ -336,6 +336,7 @@ test('confit', function (t) {
             t.error(err);
             t.ok(config);
             t.equal(config.get('nested:foo:bar'), true);
+            t.equal(config.get('NODE_ENV'), 'development');
             t.equal(config.get('nested:foo:jazz'), 'hands');
             t.end();
         });
@@ -346,6 +347,27 @@ test('confit', function (t) {
 
     });
 
+    t.test('override with stringified number as env variable', function (t) {
+        var factory;
+        var env = process.env;
+
+        process.env = {
+            nested: "8000"
+        };
+
+        factory = confit(path.join(__dirname, 'fixtures', 'defaults'));
+        factory.create(function (err, config) {
+            t.error(err);
+            t.ok(config);
+            t.equal(config.get('nested'), 8000);
+            t.end();
+        });
+
+        t.on('end', function () {
+            process.env = env;
+        });
+
+    });
     t.test('confit addOverride as json object', function (t) {
         var basedir;
         basedir = path.join(__dirname, 'fixtures', 'config');

--- a/test/fixtures/defaults/config.json
+++ b/test/fixtures/defaults/config.json
@@ -1,5 +1,11 @@
 {
     "default": "config",
     "override": "config",
-    "misc": "path:./config.json"
+    "misc": "path:./config.json",
+    "nested": {
+      "foo": {
+        "bar": "baz",
+        "jazz": "hands"
+      }
+    }
 }


### PR DESCRIPTION
This allows confit to parse stringified JSON environment variables and override deeply nested configuration properties.
