### PR TITLE
Support deep property changes in env and argv overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ Precedence takes the following form (lower numbers overwrite higher numbers):
 4. main config (`config.json`)
 5. `env` normalization (`env`, `env:development`, etc)
 
+Set deep properties with command line arguments and env variables using the
+same colon-delimited syntax used by `config.get()` and `config.set()`:
+```sh
+$ node app.js --foo:bar=baz
+```
+
 #### Shortstop Handlers
 
 Confit by default comes with 2 shortstop handlers enabled.

--- a/lib/common.js
+++ b/lib/common.js
@@ -46,6 +46,60 @@ export default {
         }
 
         return src;
+    },
+
+    getPropFromColonSepString(obj, str) {
+
+        if (Thing.isString(str) && str.length) {
+
+            str = str.split(':');
+
+            while (obj && str.length) {
+                if (obj.constructor !== Object) {
+                    // Do not allow traversal into complex types,
+                    // such as Buffer, Date, etc. So, this type
+                    // of key will fail: 'foo:mystring:length'
+                    return undefined;
+                }
+                obj = obj[str.shift()];
+            }
+
+            return obj;
+
+        }
+
+        return undefined;
+    },
+
+    setPropFromColonSepString(obj, str, value) {
+
+        var prop;
+
+        if (Thing.isString(str) && str.length) {
+
+            str = str.split(':');
+
+            while (str.length - 1) {
+                prop = str.shift();
+
+                // Create new object for property, if nonexistent
+                if (!obj.hasOwnProperty(prop)) {
+                    obj[prop] = {};
+                }
+
+                obj = obj[prop];
+                if (obj && obj.constructor !== Object) {
+                    // Do not allow traversal into complex types,
+                    // such as Buffer, Date, etc. So, this type
+                    // of key will fail: 'foo:mystring:length'
+                    return undefined;
+                }
+            }
+
+            return (obj[str.shift()] = value);
+        }
+
+        return undefined;
     }
 
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,6 +22,11 @@ export default class Config {
         this._store = data;
     }
 
+    toJSON() {
+      //TODO: consider a deep clone for maximum safety
+      return Object.assign({}, this._store);
+    }
+
     get(key) {
         var obj;
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,65 +22,12 @@ export default class Config {
         this._store = data;
     }
 
-    toJSON() {
-      //TODO: consider a deep clone for maximum safety
-      return Object.assign({}, this._store);
-    }
-
     get(key) {
-        var obj;
-
-        if (Thing.isString(key) && key.length) {
-
-            key = key.split(':');
-            obj = this._store;
-
-            while (obj && key.length) {
-                if (obj.constructor !== Object) {
-                    // Do not allow traversal into complex types,
-                    // such as Buffer, Date, etc. So, this type
-                    // of key will fail: 'foo:mystring:length'
-                    return undefined;
-                }
-                obj = obj[key.shift()];
-            }
-
-            return obj;
-
-        }
-
-        return undefined;
+		return Common.getPropFromColonSepString(this._store, key);
     }
 
     set(key, value) {
-        var obj, prop;
-
-        if (Thing.isString(key) && key.length) {
-
-            key = key.split(':');
-            obj = this._store;
-
-            while (key.length - 1) {
-                prop = key.shift();
-
-                // Create new object for property, if nonexistent
-                if (!obj.hasOwnProperty(prop)) {
-                    obj[prop] = {};
-                }
-
-                obj = obj[prop];
-                if (obj && obj.constructor !== Object) {
-                    // Do not allow traversal into complex types,
-                    // such as Buffer, Date, etc. So, this type
-                    // of key will fail: 'foo:mystring:length'
-                    return undefined;
-                }
-            }
-
-            return (obj[key.shift()] = value);
-        }
-
-        return undefined;
+		return Common.setPropFromColonSepString(this._store, key, value);
     }
 
     use(obj) {

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -16,41 +16,41 @@
 import minimist from 'minimist';
 import debuglog from 'debuglog';
 import Common from './common.js';
-
+import Config from './config.js';
 
 const debug = debuglog('confit');
 
 export default {
 
     argv() {
-        let result = {};
         let args = minimist(process.argv.slice(2));
+        let resultConfig = new Config({});
 
         for (let key of Object.keys(args)) {
             if (key === '_') {
                 // Since the '_' args are standalone,
                 // just set keys with null values.
                 for (let prop of args._) {
-                    result[prop] = null;
+                    resultConfig.set(prop, null);
                 }
             } else {
-                result[key] = args[key];
+                resultConfig.set(key, args[key]);
             }
         }
 
-        return result;
+        return resultConfig.toJSON();
     },
 
     env() {
-        let result = {};
+        let resultConfig = new Config({});
 
         // process.env is not a normal object, so we
         // need to map values.
         for (let env of Object.keys(process.env)) {
-            result[env] = process.env[env];
+            resultConfig.set(env, process.env[env]);
         }
 
-        return result;
+        return resultConfig.toJSON();
     },
 
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -16,7 +16,6 @@
 import minimist from 'minimist';
 import debuglog from 'debuglog';
 import Common from './common.js';
-import Config from './config.js';
 
 const debug = debuglog('confit');
 
@@ -24,33 +23,33 @@ export default {
 
     argv() {
         let args = minimist(process.argv.slice(2));
-        let resultConfig = new Config({});
+        let result = {};
 
         for (let key of Object.keys(args)) {
             if (key === '_') {
                 // Since the '_' args are standalone,
                 // just set keys with null values.
                 for (let prop of args._) {
-                    resultConfig.set(prop, null);
+                    Common.setPropFromColonSepString(result, prop, null);
                 }
             } else {
-                resultConfig.set(key, args[key]);
+                Common.setPropFromColonSepString(result, key, args[key]);
             }
         }
 
-        return resultConfig.toJSON();
+        return result;
     },
 
     env() {
-        let resultConfig = new Config({});
+        let result = {};
 
         // process.env is not a normal object, so we
         // need to map values.
         for (let env of Object.keys(process.env)) {
-            resultConfig.set(env, process.env[env]);
+            Common.setPropFromColonSepString(result, env, process.env[env]);
         }
 
-        return resultConfig.toJSON();
+        return result;
     },
 
 

--- a/test/provider-test.js
+++ b/test/provider-test.js
@@ -11,7 +11,7 @@ test('env', function (t) {
         process.env = env;
     });
 
-    t.test('env variables', function () {
+    t.test('env variables', function (t) {
         var val;
 
         process.env = {
@@ -21,6 +21,18 @@ test('env', function (t) {
         val = provider.env();
         t.equal(val.foo, 'bar');
         t.end();
+    });
+
+    t.test('deep env variables', function (t) {
+      var val;
+
+      process.env = {
+        'foo:bar': 'baz'
+      };
+
+      val = provider.env();
+      t.deepEqual(val.foo, { bar: 'baz' });
+      t.end();
     });
 });
 
@@ -45,6 +57,16 @@ test('argv', function (t) {
         t.equal(val.g, null);
         t.equal(val.h, null);
         t.end();
+    });
+
+    t.test('deep arguments', function (t) {
+      var val;
+
+      process.argv = [ 'node', __filename, '--foo:bar=baz' ];
+
+      val = provider.argv();
+      t.deepEqual(val.foo, { bar: 'baz' });
+      t.end();
     });
 });
 


### PR DESCRIPTION
Confit allows command-line arguments and environment variables to take precedence over config files. However, as observed in https://github.com/krakenjs/confit/issues/42, it does not support setting complex properties. This change uses the existing object traversal code that confit already provides in its JavaScript API to read command-line arguments and environment variables. It enables this:

``` sh
$ node app.js --a:b:c=d
```

The resulting overridden config value would be:

``` json
{
  "a": {
    "b": {
      "c": "d"
    }
  }
}
```
