### PR TITLE
Remove babel-runtime in compile step so that there is no hard dependency on babel4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dist": "dist"
   },
   "scripts": {
-    "compile": "babel --optional runtime --modules common --out-dir dist index.js lib/**.js",
+    "compile": "babel --modules common --out-dir dist index.js lib/**.js",
     "prepublish": "npm run compile",
     "test": "npm run compile && babel-node test/harness.js test/**/*-test.js",
     "cover": "npm run compile && babel-node node_modules/.bin/istanbul cover test/harness.js test/**/*-test.js"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "babel": "4.7.3",
+    "babel-runtime": "^4.7.3",
     "glob": "^4.3.5",
     "istanbul": "^0.3.5",
     "jshint": "^2.6.0",
@@ -39,7 +40,6 @@
   },
   "dependencies": {
     "async": "^0.9.0",
-    "babel-runtime": "4.7.3",
     "caller": "^1.0.0",
     "core-util-is": "^1.0.1",
     "debuglog": "^1.0.1",


### PR DESCRIPTION
The tests seem to run fine. Since this is published transpiled and we're not using anything that needs the regenerator, I'm guessing this shouldn't affect anything. We can do a minor version bump to be safe?
