### PR TITLE
Not allowing process.env.env to override the env:env value

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -47,7 +47,11 @@ export default {
         // process.env is not a normal object, so we
         // need to map values.
         for (let env of Object.keys(process.env)) {
-            result[env] = process.env[env];
+            //env:env is decided by process.env.NODE_ENV.
+            //Not allowing process.env.env to override the env:env value.
+            if (env !== 'env') {
+                result[env] = process.env[env];
+            }
         }
 
         return result;
@@ -79,4 +83,3 @@ export default {
         return { env };
     }
 }
-

--- a/test/confit-test.js
+++ b/test/confit-test.js
@@ -26,6 +26,10 @@ test('confit', function (t) {
 
 
     t.test('get', function (t) {
+        //setting process.env.env to development, should not change 'env:env'.
+        //This should be ignored and 'env:env' should solely depend on process.env.NODE_ENV
+        process.env.env = 'development';
+
         confit().create(function (err, config) {
             var val;
 
@@ -493,4 +497,3 @@ test('confit', function (t) {
     });
 
 });
-

--- a/test/provider-test.js
+++ b/test/provider-test.js
@@ -15,11 +15,14 @@ test('env', function (t) {
         var val;
 
         process.env = {
-            foo: 'bar'
+            foo: 'bar',
+            env: 'development'
         };
 
         val = provider.env();
         t.equal(val.foo, 'bar');
+        //env() provider ignores process.env.env
+        t.equal(val.env, undefined);
         t.end();
     });
 });


### PR DESCRIPTION
-  https://github.com/krakenjs/confit/issues/56
- `env:env` is set based on the `NODE_ENV`, so do not allow environment property named `env` to override the value.
