### PR TITLE
support an array of handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ confit(options)
 ## Options
 * `basedir` (*String*) - the base directory in which config files can be found.
 * `protocols` (*Object*) - An object containing a mapping of
-[shortstop](https://github.com/paypal/shortstop) protocols to handler implementations.
-This protocols will be used to process the config data prior to registration.
+[shortstop](https://github.com/paypal/shortstop) protocols to either handler implementations or an array or handler implementations.
+These protocols will be used to process the config data prior to registration.
+If using an array of handler implementations, each handler is run in series (see [`Multiple handlers` in the shortstop README](https://github.com/krakenjs/shortstop#multiple-handlers)).
 * `defaults` (*String*) - the name of the file containing all default values.
 Defaults to `config.json`.
 

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -100,7 +100,15 @@ export default class Handlers {
             let shorty = Shortstop.create();
 
             for (let protocol of Object.keys(protocols)) {
-                shorty.use(protocol, protocols[protocol]);
+                let impls = protocols[protocol];
+                
+                if (Array.isArray(impls)) {
+                    for (let impl of impls) {
+                        shorty.use(protocol, impl);
+                    }
+                } else {
+                    shorty.use(protocol, impls);
+                }
             }
 
             shorty.resolve(data, function (err, data) {

--- a/test/confit-test.js
+++ b/test/confit-test.js
@@ -388,6 +388,38 @@ test('confit', function (t) {
     });
 
 
+    t.test('protocols (array)', function (t) {
+        var basedir, options;
+
+        process.env.NODE_ENV = 'dev';
+        basedir = path.join(__dirname, 'fixtures', 'defaults');
+        options = {
+            basedir: basedir,
+            protocols: {
+                path: [
+                    function (value) {
+                        return path.join(basedir, value);
+                    },
+                    function (value) {
+                        return value + '!';
+                    }
+                ]
+            }
+        };
+
+        confit(options).create(function (err, config) {
+            t.error(err);
+            // Ensure handler was run correctly on default file
+            t.equal(config.get('misc'), path.join(basedir, 'config.json!'));
+            t.equal(config.get('path'), path.join(basedir, 'development.json!'));
+
+            config.use({ path: __filename });
+            t.equal(config.get('path'), __filename);
+            t.end();
+        });
+    });
+
+
     t.test('error', function (t) {
         var basedir, options;
 


### PR DESCRIPTION
`shortstop` supports [registering multiple handlers](https://github.com/krakenjs/shortstop#multiple-handlers) against a shortstop prefix.
The `confit` implementation, however, doesn't allow for it. This change adds that support.
