### PR TITLE
add feature for ignoring environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ These protocols will be used to process the config data prior to registration.
 If using an array of handler implementations, each handler is run in series (see [`Multiple handlers` in the shortstop README](https://github.com/krakenjs/shortstop#multiple-handlers)).
 * `defaults` (*String*) - the name of the file containing all default values.
 Defaults to `config.json`.
+* `envignore` (*Array*) - any properties found in `process.env` that should be ignored
 
 ```javascript
 'use strict';

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -27,7 +27,8 @@ const debug = debuglog('confit');
 
 export default class Factory {
 
-    constructor({ basedir, protocols =  {}, defaults = 'config.json' }) {
+    constructor({ basedir, protocols =  {}, defaults = 'config.json', envignore = []}) {
+        this.envignore = envignore.push('env');
         this.basedir = basedir;
         this.protocols = protocols;
         this.promise = Promise.resolve({})
@@ -42,7 +43,7 @@ export default class Factory {
                 return Handlers.resolveImport(shush(file), this.basedir)
                     .then(data => Common.merge(shush(file), store));
             }))
-            .then(store => Common.merge(Provider.env(), store))
+            .then(store => Common.merge(Provider.env(envignore), store))
             .then(store => Common.merge(Provider.argv(), store));
     }
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -41,7 +41,7 @@ export default {
         return result;
     },
 
-    env() {
+    env(ignore) {
         let result = {};
 
         // process.env is not a normal object, so we
@@ -49,7 +49,7 @@ export default {
         for (let env of Object.keys(process.env)) {
             //env:env is decided by process.env.NODE_ENV.
             //Not allowing process.env.env to override the env:env value.
-            if (env !== 'env') {
+            if (ignore.indexOf(env) < 0) {
                 result[env] = process.env[env];
             }
         }

--- a/test/confit-test.js
+++ b/test/confit-test.js
@@ -527,5 +527,28 @@ test('confit', function (t) {
             t.end();
         });
     });
+    t.test('env ignore', function (t) {
+        var basedir, options;
+
+        var env = process.env = {
+            NODE_ENV: 'development',
+            fromlocal: 'config:local',
+            local: 'motion',
+            ignoreme: 'file:./path/to/mindyourbusiness'
+        };
+        basedir = path.join(__dirname, 'fixtures', 'defaults');
+        options = {
+            basedir: basedir,
+            envignore: ['ignoreme']
+        };
+
+        confit(options).create(function (err, config) {
+            t.error(err);
+            // Ensure env is read except for the desired ignored property
+            t.equal(config.get('fromlocal'), env.local);
+            t.equal(config.get('ignoreme'), undefined);
+            t.end();
+        });
+    });
 
 });

--- a/test/provider-test.js
+++ b/test/provider-test.js
@@ -19,7 +19,7 @@ test('env', function (t) {
             env: 'development'
         };
 
-        val = provider.env();
+        val = provider.env(['env']);
         t.equal(val.foo, 'bar');
         //env() provider ignores process.env.env
         t.equal(val.env, undefined);


### PR DESCRIPTION
Per: https://github.com/krakenjs/kraken-js/issues/470

Processing all environment variables can result in a shortstop handler (such as `file`) throwing an error when there was no intention of engaging said handler. As in the issue above, the npm local_modules feature uses the `file:` prefix. The shortstop-handler `file` will throw an `EISDIR` error.

With this PR, there would be the ability to pass in an array of environment properties that confit should completely ignore.