### PR TITLE
make sure we can resolve JSON imports without .json file extension

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -77,6 +77,8 @@ export default class Handlers {
             let shorty = Shortstop.create();
 
             shorty.use('import', function (file, cb) {
+                //check for json extension
+                file = (/\.json$/.test(file)) ? file : `${file}.json`;
                 try {
                     file = path(file);
                     return shorty.resolve(loadJsonicSync(file), cb);

--- a/test/fixtures/import/child.json
+++ b/test/fixtures/import/child.json
@@ -1,4 +1,4 @@
 {
     "name": "child",
-    "grandchild": "import:./grandchild.json"
+    "grandchild": "import:./grandchild"
 }


### PR DESCRIPTION
`load-jsonic-sync` doesn't account for files specified without their file extension. The original intent was that people could use "require-like" syntax, which implies no file extension. The unit tests didn't cover that use case so this wasn't caught.

Probably the "right" fix is to `load-jsonic-sync` but this is the quickest way to get out a fix right now.