### PR TITLE
Enabled array on .get configurations

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -31,15 +31,27 @@ class Config {
 
             key = key.split(':');
             obj = this._store;
+            var isArray = false;
 
             while (obj && key.length) {
+                if (isArray) {
+                    var idx = Number(key[0]);
+                    if (Number.isInteger(idx) && idx >= 0) {
+                        if (obj.length <= idx) return undefined;
+                        
+                        obj = obj[key.shift()];
+                    }
+                }
+
                 if (obj.constructor !== Object) {
                     // Do not allow traversal into complex types,
                     // such as Buffer, Date, etc. So, this type
                     // of key will fail: 'foo:mystring:length'
                     return undefined;
-                }
+                }                
+
                 obj = obj[key.shift()];
+                isArray = Array.isArray(obj);
             }
 
             return obj;

--- a/test/confit-test.js
+++ b/test/confit-test.js
@@ -26,11 +26,13 @@ test('confit', function (t) {
 
 
     t.test('get', function (t) {
+        var basedir;
         //setting process.env.env to development, should not change 'env:env'.
         //This should be ignored and 'env:env' should solely depend on process.env.NODE_ENV
         process.env.env = 'development';
+        basedir = path.join(__dirname, 'fixtures', 'config');
 
-        confit().create(function (err, config) {
+        confit(basedir).create(function (err, config) {
             var val;
 
             t.error(err);
@@ -69,6 +71,19 @@ test('confit', function (t) {
             t.equal(typeof val, 'undefined');
 
             val = config.get(false);
+            t.equal(typeof val, 'undefined');
+
+            val = config.get('arr');
+            t.equal(typeof val, 'object');
+            t.equal(Array.isArray(val), true);
+
+            val = config.get('arr:0:name');
+            t.equal(val, 'object1');
+
+            val = config.get('arr_empty:0');
+            t.equal(typeof val, 'undefined');
+
+            val = config.get('arr_empty:0:name');
             t.equal(typeof val, 'undefined');
 
             t.end();

--- a/test/fixtures/config/config.json
+++ b/test/fixtures/config/config.json
@@ -11,5 +11,9 @@
         }
     },
     "value": false,
+    "arr":[{
+        "name": "object1"
+    }],
+    "arr_empty":[],
     "imported": "import:./child.json"
 }


### PR DESCRIPTION
This will allow direct queries into array dependencies.
Sample Config:
```
{
  "arguments":[
    "featureX": {
      "name": "test"
    },
  ],
}
```
Before: `.get("arguments")[0].featureX`
After: `.get("arguments:0:featureX")`