### PR TITLE
Create APP_ENV to satisfy Next.js preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ config.get('a:b:c'); // 'd'
 ## Default Behavior
 By default, `confit` loads `process.env` and `argv` values upon initialization.
 Additionally, it creates convenience environment properties prefixed with
-`env:` based on the current `NODE_ENV` setting, defaulting to `development`. It
-also normalizes `NODE_ENV` settings so values starting with `prod` become
+`env:` based on the current `APP_ENV` or `NODE_ENV` setting, defaulting to `development`. It
+also normalizes `APP_ENV`/`NODE_ENV` settings so values starting with `prod` become
 `production`, starting with `stag` become `staging`, starting with `test`
 become `test` and starting with `dev` become `development`.
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -49,7 +49,7 @@ module.exports = {
         // process.env is not a normal object, so we
         // need to map values.
         for (let env of Object.keys(process.env)) {
-            //env:env is decided by process.env.NODE_ENV.
+            //env:env is decided by process.env.APP_ENV or process.env.NODE_ENV.
             //Not allowing process.env.env to override the env:env value.
             if (ignore.indexOf(env) < 0) {
                 result[env] = process.env[env];
@@ -63,10 +63,10 @@ module.exports = {
     convenience() {
         var nodeEnv, env;
 
-        nodeEnv = process.env.NODE_ENV || 'development';
+        nodeEnv = process.env.APP_ENV || process.env.NODE_ENV || 'development';
         env = {};
 
-        debug(`NODE_ENV set to ${nodeEnv}`);
+        debug(`APP_ENV/NODE_ENV set to ${nodeEnv}`);
 
         // Normalize env and set convenience values.
         for (let current of Object.keys(Common.env)) {
@@ -78,7 +78,7 @@ module.exports = {
         debug(`env:env set to ${nodeEnv}`);
 
         // Set (or re-set) env:{nodeEnv} value in case
-        // NODE_ENV was not one of our predetermined env
+        // APP_ENV/NODE_ENV was not one of our predetermined env
         // keys (so `config.get('env:blah')` will be true).
         env[nodeEnv] = true;
         env.env = nodeEnv;


### PR DESCRIPTION
Next.js is very opinionated that NODE_ENV should only ever by production/development (maybe test, can't remember). Anyhow "staging" is not allowed and bad things happen. So I've made another environment variable - APP_ENV - to supersede NODE_ENV if set. I don't really expect a merge, but here it is anyhow.