### PR TITLE
refactor: swap to native debuglog implementation

### DIFF
--- a/lib/factory.js
+++ b/lib/factory.js
@@ -17,7 +17,7 @@
 
 const Path = require('path');
 const shush = require('shush');
-const debuglog = require('debuglog');
+const { debuglog } = require('util');
 const Thing = require('core-util-is');
 const Config = require('./config');
 const Common = require('./common');

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const minimist = require('minimist');
-const debuglog = require('debuglog');
+const { debuglog } = require('util');
 const Common = require('./common');
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,5650 @@
 {
   "name": "confit",
   "version": "3.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "confit",
+      "version": "3.0.0",
+      "dependencies": {
+        "async": "^2.6.3",
+        "caller": "^1.0.1",
+        "core-util-is": "^1.0.2",
+        "minimist": "^1.2.5",
+        "shortstop": "^1.0.3",
+        "shortstop-handlers": "^1.0.1",
+        "shush": "^1.0.0"
+      },
+      "devDependencies": {
+        "glob": "^7.1.6",
+        "jshint": "^2.11.0",
+        "nyc": "^15.0.0",
+        "tap": "^14.10.8"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha1-Fo2ho26Q2miujUnA8bSMfGJJITo=",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.12.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/core/-/core-7.12.3.tgz",
+      "integrity": "sha1-G0NohOHjv/b7EyjcArIIdZ3pKtg=",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.12.1",
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helpers": "^7.12.1",
+        "@babel/parser": "^7.12.3",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.12.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/generator/-/generator-7.12.5.tgz",
+      "integrity": "sha1-osUN5ci21wirlb5eYFOTbBiEpN4=",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.5",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.10.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+      "integrity": "sha1-0tOyDFmtjEcRL6fSqUvAnV74Lxo=",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/@babel/helper-get-function-arity": {
+      "version": "7.10.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+      "integrity": "sha1-mMHL6g4jMvM/mkZhuM4VBbLBm6I=",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.12.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+      "integrity": "sha1-+6Dy/P8/ugDm7LZku15uJuLWFlw=",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.1"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.12.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+      "integrity": "sha1-G/wCKfeUmI927QpNTpCGCFC1Tfs=",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.5"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.12.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+      "integrity": "sha1-eVT+xx9bMsSOSzA7Q3w0RT/XJHw=",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-replace-supers": "^7.12.1",
+        "@babel/helper-simple-access": "^7.12.1",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
+        "lodash": "^4.17.19"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.10.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+      "integrity": "sha1-UNyWQT1ZT5lad5BZBbBYk813lnM=",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.12.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
+      "integrity": "sha1-8AmhdUO7u84WsGIGrnO2PT/KaNk=",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.12.1",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.12.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+      "integrity": "sha1-MkJ+WqYVR9OOsebq9f0UJv2tkTY=",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.1"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.11.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+      "integrity": "sha1-+KSRJErPamdhWKxCBykRuoOtCZ8=",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.11.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha1-p4x6clHgH2FlEtMbEK3PUq2l4NI=",
+      "dev": true
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.12.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/helpers/-/helpers-7.12.5.tgz",
+      "integrity": "sha1-Ghukp2jZtYMQ7aUWxEmRP+ZHEW4=",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha1-fRvf1ldTU4+r5sOFls23bZrGAUM=",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.12.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/parser/-/parser-7.12.5.tgz",
+      "integrity": "sha1-tK8y3dRzwL+mQ71/8HKLjnG4HqA=",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.10.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/template/-/template-7.10.4.tgz",
+      "integrity": "sha1-MlGZbEIA68cdGo/EBfupQPNrong=",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.12.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/traverse/-/traverse-7.12.5.tgz",
+      "integrity": "sha1-eKDGjI6KNeTKz9MduLswPVYG8JU=",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.12.5",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/parser": "^7.12.5",
+        "@babel/types": "^7.12.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.12.6",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@babel/types/-/types-7.12.6.tgz",
+      "integrity": "sha1-rg5V7xzOH7yIHNJvgjTrPmV+3JY=",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "lodash": "^4.17.19",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha1-/T2x1Z7PfPEh6AZQu4ZxL5tV7O0=",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha1-JlIL8Jq+SlZEzVQU43ElqJVCQd0=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/append-transform": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha1-mdnSnHs4OR5vQo0ozhNlUfC3fhI=",
+      "dev": true,
+      "dependencies": {
+        "default-require-extensions": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/archy": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha1-Jp/HrVuOQstjyJbVZmAXJhwUQIk=",
+      "dev": true
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/async": {
+      "version": "2.6.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/async/-/async-2.6.3.tgz",
+      "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/async-hook-domain": {
+      "version": "1.1.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/async-hook-domain/-/async-hook-domain-1.1.3.tgz",
+      "integrity": "sha1-9PUxuO6CBrHqGCX+OCXgFcZvRNA=",
+      "dev": true,
+      "dependencies": {
+        "source-map-support": "^0.5.11"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.11.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk=",
+      "dev": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha1-MPpAyef+B9vIlWeM0ocCTeokHdk=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bind-obj-methods": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/bind-obj-methods/-/bind-obj-methods-2.0.0.tgz",
+      "integrity": "sha1-AXgUDb57e7Z9x0iSrOWbwCR/BvA=",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha1-PJtLfXgsgSHlbxAQbYTA0P/JRiY=",
+      "dev": true
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "dev": true
+    },
+    "node_modules/caching-transform": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha1-ANKXpCBtceIWPDnq/6gVesBlHw8=",
+      "dev": true,
+      "dependencies": {
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caller": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/caller/-/caller-1.0.1.tgz",
+      "integrity": "sha1-uFGGD3Dhlds9J3OVqhp+I+ow7PU="
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.4.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/chokidar/-/chokidar-3.4.3.tgz",
+      "integrity": "sha1-wd84IxRI5FykrFiObHlXO6alfVs=",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.5.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.1.2"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "dependencies": {
+        "exit": "0.1.2",
+        "glob": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=0.2.5"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
+      "dev": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/console-browserify": {
+      "version": "1.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "dependencies": {
+        "date-now": "^0.1.4"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "node_modules/coveralls": {
+      "version": "3.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/coveralls/-/coveralls-3.1.0.tgz",
+      "integrity": "sha1-E8dU1eei3YtE/lJp4hyjlPtNYVs=",
+      "dev": true,
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "lcov-parse": "^1.0.0",
+        "log-driver": "^1.2.7",
+        "minimist": "^1.2.5",
+        "request": "^2.88.2"
+      },
+      "bin": {
+        "coveralls": "bin/coveralls.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cp-file": {
+      "version": "6.2.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/cp-file/-/cp-file-6.2.0.tgz",
+      "integrity": "sha1-QNXqSh3vKprN0HulwLAkbvc9wQ0=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^2.0.0",
+        "nested-error-stacks": "^2.0.0",
+        "pify": "^4.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cp-file/node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+      "dev": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cp-file/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/date-now": {
+      "version": "0.1.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.2.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha1-fxUPk5IOlMWPVXTC/QGjEQ7/5/E=",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "0.1.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/deep-equal/-/deep-equal-0.1.2.tgz",
+      "integrity": "sha1-skbCuApXCkfBG+HZvRBw7IeLh84="
+    },
+    "node_modules/default-require-extensions": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+      "integrity": "sha1-4D+TqsmytkQ/xS5eSjezrZrY35Y=",
+      "dev": true,
+      "dependencies": {
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/defined": {
+      "version": "0.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4="
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-frag": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/diff-frag/-/diff-frag-1.0.1.tgz",
+      "integrity": "sha1-p7tReJdD6MC0DiUJFmvRVeWDOCY=",
+      "dev": true
+    },
+    "node_modules/dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha1-GvuB9TNxcXXUeGVd68XjMtn5u1E=",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/domelementtype": {
+      "version": "2.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/domelementtype/-/domelementtype-2.0.2.tgz",
+      "integrity": "sha1-87blSSAeRvWItZRj3XcYcTH+aXE=",
+      "dev": true
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "2.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha1-mS0xKc999ocLlsV4WMJJoSD4uLU=",
+      "dev": true
+    },
+    "node_modules/domelementtype": {
+      "version": "1.3.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8=",
+      "dev": true
+    },
+    "node_modules/domhandler": {
+      "version": "2.3.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "1.5.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "dependencies": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true
+    },
+    "node_modules/entities": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "dev": true
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha1-njr0B0Wd7tR+mpH5uIWoTrBcVh0=",
+      "dev": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha1-NCwYwp1WFXaIulzjH4Qx+7eVzBA=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/events-to-array": {
+      "version": "1.1.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/events-to-array/-/events-to-array-1.1.2.tgz",
+      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+      "dev": true
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+      "dev": true
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+      "dev": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
+      "dev": true
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+      "integrity": "sha1-ibM/rUpGcNqpT4Vff74x1thP6IA=",
+      "dev": true,
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/findit": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/findit/-/findit-2.0.0.tgz",
+      "integrity": "sha1-ZQnwEmr0wXhVHPqZOU4DLhOk1W4=",
+      "dev": true
+    },
+    "node_modules/flow-parser": {
+      "version": "0.137.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/flow-parser/-/flow-parser-0.137.0.tgz",
+      "integrity": "sha1-jAVhL/k0RkjYvN6qTFjRMeh12EI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/flow-remove-types": {
+      "version": "2.137.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/flow-remove-types/-/flow-remove-types-2.137.0.tgz",
+      "integrity": "sha1-RlMDXATeA6kXfoXl0JOR/RTnA+k=",
+      "dev": true,
+      "dependencies": {
+        "flow-parser": "^0.137.0",
+        "pirates": "^3.0.2",
+        "vlq": "^0.2.1"
+      },
+      "bin": {
+        "flow-node": "flow-node",
+        "flow-remove-types": "flow-remove-types"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha1-cbMoAMnxWqjy+D9Ka9m/812GGlM=",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/fromentries": {
+      "version": "1.3.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha1-5LymgIgWv4+TtSdQ8RJ/Wm/Ybjo=",
+      "dev": true
+    },
+    "node_modules/fs-exists-cached": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
+      "integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=",
+      "dev": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "node_modules/fsevents": {
+      "version": "2.1.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
+      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "dev": true
+    },
+    "node_modules/function-loop": {
+      "version": "1.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/function-loop/-/function-loop-1.0.2.tgz",
+      "integrity": "sha1-Frk911eEXqz+yhqAYaamXBBuDLI=",
+      "dev": true
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha1-jeLYA8/0TfO8bEVuZmizbDkm4Ro=",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs=",
+      "dev": true
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
+      "deprecated": "this library is no longer supported",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/has/-/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hasha": {
+      "version": "5.2.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha1-pIR3mJs7MnrqPAT1MJbYFtl1IqE=",
+      "dev": true,
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.8",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha1-dTm9S8Hg4KiVgVouAmJCCxKFhIg=",
+      "dev": true
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
+      "dev": true
+    },
+    "node_modules/htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-core-module/-/is-core-module-2.1.0.tgz",
+      "integrity": "sha1-pMwDHZsaymPuy9GKZQ4Ty07quUY=",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha1-venDJoDW+uBBKdasnZIc54FfeOM=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+      "integrity": "sha1-9ZRKN8cLVQsCp4pcOyBVsoDOyOw=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-hook": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha1-j4TJQ0iIzGsdCp1wkqdtI56/DMY=",
+      "dev": true,
+      "dependencies": {
+        "append-transform": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "4.0.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha1-hzxv/4l0UBGCIndGlqPyiQLXfB0=",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.7.5",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo": {
+      "version": "2.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
+      "integrity": "sha1-4UJlFGYiRLLyXfco6P0bo1/lO5w=",
+      "dev": true,
+      "dependencies": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.0",
+        "istanbul-lib-coverage": "^3.0.0-alpha.1",
+        "make-dir": "^3.0.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha1-dRj+UupE3jcvRgp2tezan/tz2KY=",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+      "integrity": "sha1-dXQ85tlruG3H7kNSz2Nmoj8LGtk=",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha1-1ZMhDlAAaDdQywn8BkTktuJ/1Ts=",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "1.4.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/jackspeak/-/jackspeak-1.4.0.tgz",
+      "integrity": "sha1-TrLHk1xebSgXm1CClxHRNyocmio=",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jackspeak/node_modules/cliui": {
+      "version": "4.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "node_modules/jackspeak/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jackspeak/node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jackspeak/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jackspeak/node_modules/wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jackspeak/node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jackspeak/node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jackspeak/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jackspeak/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jshint": {
+      "version": "2.12.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/jshint/-/jshint-2.12.0.tgz",
+      "integrity": "sha1-Uudb0FjVh++BoOL5XlzxjrXcXDc=",
+      "dev": true,
+      "dependencies": {
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "~4.17.19",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
+      },
+      "bin": {
+        "jshint": "bin/jshint"
+      }
+    },
+    "node_modules/jshint/node_modules/strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true,
+      "bin": {
+        "strip-json-comments": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+      "dev": true
+    },
+    "node_modules/json-schema": {
+      "version": "0.2.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "node_modules/json5": {
+      "version": "2.1.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha1-ybD3+pIzv+WAf+ZvzzpWF+1ZfUM=",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "node_modules/lcov-parse": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/lcov-parse/-/lcov-parse-1.0.0.tgz",
+      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+      "dev": true,
+      "bin": {
+        "lcov-parse": "bin/cli.js"
+      }
+    },
+    "node_modules/load-json-file": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.20",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI="
+    },
+    "node_modules/lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "node_modules/log-driver": {
+      "version": "1.2.7",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha1-Y7lQIfBwL+36LJuwok53l9cYcdg=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+      "dev": true,
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha1-LrLjfqm2fEiR9oShOUeZr0hM96I=",
+      "dev": true
+    },
+    "node_modules/merge-source-map": {
+      "version": "1.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
+      "dev": true,
+      "dependencies": {
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/merge-source-map/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.44.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha1-+hHF6wrKEzS0Izy01S8QxaYnL5I=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.27",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha1-R5SfmOJ56lMRn1ci4PNOUpvsAJ8=",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.44.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
+    },
+    "node_modules/minipass": {
+      "version": "3.1.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha1-fUL/HzljVILhX5zbUxhN7r1YFf0=",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+      "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "dev": true
+    },
+    "node_modules/nested-error-stacks": {
+      "version": "2.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+      "integrity": "sha1-D73PPhP+SZR4EoBST4uWsM3/nGE=",
+      "dev": true
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+      "dev": true
+    },
+    "node_modules/node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-preload": {
+      "version": "0.2.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha1-wDBDuzJ/QXoY/uerfuV7QIoUQwE=",
+      "dev": true,
+      "dependencies": {
+        "process-on-spawn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nyc": {
+      "version": "15.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/nyc/-/nyc-15.1.0.tgz",
+      "integrity": "sha1-EzXa4S3ch7biSdWhmUykva6nXwI=",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^2.0.0",
+        "get-package-type": "^0.1.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.1",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "yargs": "^15.0.2"
+      },
+      "bin": {
+        "nyc": "bin/nyc.js"
+      },
+      "engines": {
+        "node": ">=8.9"
+      }
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha1-XTfh81B3udysQwE3InGv3rKhNZg=",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/own-or": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/own-or/-/own-or-1.0.0.tgz",
+      "integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw=",
+      "dev": true
+    },
+    "node_modules/own-or-env": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/own-or-env/-/own-or-env-1.0.1.tgz",
+      "integrity": "sha1-VM5gHTv3gjbFxlYzqhyOwD+AB+Q=",
+      "dev": true,
+      "dependencies": {
+        "own-or": "^1.0.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha1-1wTZr4orpoTiYA2aIVmD1BQal50=",
+      "dev": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-hash": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha1-NTf2VGZew8w4gnOH/JBMFjxU9QY=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^5.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.6",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+      "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+      "dev": true,
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-type/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.2.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0=",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "3.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/pirates/-/pirates-3.0.2.tgz",
+      "integrity": "sha1-fm+FQT/ZFhq04StTmwYBDYWVS7k=",
+      "dev": true,
+      "dependencies": {
+        "node-modules-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/process-on-spawn": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+      "integrity": "sha1-lbBaIwc9MKF6z9ySpEDv0rrv3JM=",
+      "dev": true,
+      "dependencies": {
+        "fromentries": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.7.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "node_modules/psl": {
+      "version": "1.8.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ=",
+      "dev": true
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.5.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/react": {
+      "version": "16.14.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/react/-/react-16.14.0.tgz",
+      "integrity": "sha1-lNd23dCqo32j7aj8W2sYpMmjEU0=",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ=",
+      "dev": true
+    },
+    "node_modules/read-pkg": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "dependencies": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+      "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0",
+        "read-pkg": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.5.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha1-m6dMAZsV02UnjS6Ru4xI17TULJ4=",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "dev": true,
+      "dependencies": {
+        "es6-error": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/request/-/request-2.88.2.tgz",
+      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dev": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+      "dev": true
+    },
+    "node_modules/resolve": {
+      "version": "1.19.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha1-GvW/YwQJc0oGfK4pMYqsf6KaJnw=",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resumer": {
+      "version": "0.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dependencies": {
+        "through": "~2.3.4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "dev": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.3.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true,
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/shortstop": {
+      "version": "1.0.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/shortstop/-/shortstop-1.0.3.tgz",
+      "integrity": "sha1-1Ddpw2/ufiCjub/S0IeJNf+G58Y=",
+      "dependencies": {
+        "async": "~0.2.10",
+        "core-util-is": "~1.0.1"
+      }
+    },
+    "node_modules/shortstop-handlers": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/shortstop-handlers/-/shortstop-handlers-1.0.1.tgz",
+      "integrity": "sha1-B1WstmBMdsnA52qelD+TeQurHcQ=",
+      "dependencies": {
+        "caller": "^1.0.1",
+        "core-util-is": "^1.0.1",
+        "glob": "^7.0.5"
+      }
+    },
+    "node_modules/shortstop/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+    },
+    "node_modules/shush": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/shush/-/shush-1.0.0.tgz",
+      "integrity": "sha1-wnQVqeRY8v7TmyfPjrN8ADeCtDE=",
+      "dependencies": {
+        "caller": "~0.0.1",
+        "strip-json-comments": "~0.1.1"
+      }
+    },
+    "node_modules/shush/node_modules/caller": {
+      "version": "0.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/caller/-/caller-0.0.1.tgz",
+      "integrity": "sha1-83odbqEOgp2UchrimpC7T7Uqt2c=",
+      "dependencies": {
+        "tape": "~2.3.2"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw=",
+      "dev": true
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.19",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spawn-wrap": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha1-EDaFuLj5t5dxMYgnqnhlCmENRX4=",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha1-3s6BrJweZxPl99G28X1Gj6U9iak=",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha1-PyjOGnegA3JoPq3kpDMYNSeiFj0=",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha1-z3D1BILu/cmOPOCmgz5KU87rpnk=",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.6",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+      "integrity": "sha1-yAdXODwoq/cpZ0SZjLwQaui4VM4=",
+      "dev": true
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "node_modules/sshpk": {
+      "version": "1.16.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "dev": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "1.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/stack-utils/-/stack-utils-1.0.2.tgz",
+      "integrity": "sha1-M+ujiXeIVYvr/C2wWdwVjsNs67g=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "4.2.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha1-nDUFwdtFvO3KPZz3oW9cWqOQGHg=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "0.1.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+      "integrity": "sha1-Fkxk43Coo8wAyeAbU55WmCPw7lQ=",
+      "bin": {
+        "strip-json-comments": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap": {
+      "version": "14.10.8",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/tap/-/tap-14.10.8.tgz",
+      "integrity": "sha1-PJznlRmsyi9A5XNQUTsqpRxuV8I=",
+      "bundleDependencies": [
+        "ink",
+        "treport",
+        "@types/react"
+      ],
+      "dev": true,
+      "dependencies": {
+        "@types/react": "^16.9.16",
+        "async-hook-domain": "^1.1.3",
+        "bind-obj-methods": "^2.0.0",
+        "browser-process-hrtime": "^1.0.0",
+        "chokidar": "^3.3.0",
+        "color-support": "^1.1.0",
+        "coveralls": "^3.0.11",
+        "diff": "^4.0.1",
+        "esm": "^3.2.25",
+        "findit": "^2.0.0",
+        "flow-remove-types": "^2.112.0",
+        "foreground-child": "^1.3.3",
+        "fs-exists-cached": "^1.0.0",
+        "function-loop": "^1.0.2",
+        "glob": "^7.1.6",
+        "import-jsx": "^3.1.0",
+        "ink": "^2.6.0",
+        "isexe": "^2.0.0",
+        "istanbul-lib-processinfo": "^1.0.0",
+        "jackspeak": "^1.4.0",
+        "minipass": "^3.1.1",
+        "mkdirp": "^0.5.4",
+        "nyc": "^14.1.1",
+        "opener": "^1.5.1",
+        "own-or": "^1.0.0",
+        "own-or-env": "^1.0.1",
+        "react": "^16.12.0",
+        "rimraf": "^2.7.1",
+        "signal-exit": "^3.0.0",
+        "source-map-support": "^0.5.16",
+        "stack-utils": "^1.0.2",
+        "tap-mocha-reporter": "^5.0.0",
+        "tap-parser": "^10.0.1",
+        "tap-yaml": "^1.0.0",
+        "tcompare": "^3.0.0",
+        "treport": "^1.0.2",
+        "trivial-deferred": "^1.0.1",
+        "ts-node": "^8.5.2",
+        "typescript": "^3.7.2",
+        "which": "^2.0.2",
+        "write-file-atomic": "^3.0.1",
+        "yaml": "^1.7.2",
+        "yapool": "^1.0.0"
+      },
+      "bin": {
+        "tap": "bin/run.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap-mocha-reporter": {
+      "version": "5.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/tap-mocha-reporter/-/tap-mocha-reporter-5.0.1.tgz",
+      "integrity": "sha1-dPAL4t3So4CtrUXghXlRN7w5SXo=",
+      "dev": true,
+      "dependencies": {
+        "color-support": "^1.1.0",
+        "debug": "^4.1.1",
+        "diff": "^4.0.1",
+        "escape-string-regexp": "^2.0.0",
+        "glob": "^7.0.5",
+        "tap-parser": "^10.0.0",
+        "tap-yaml": "^1.0.0",
+        "unicode-length": "^2.0.2"
+      },
+      "bin": {
+        "tap-mocha-reporter": "index.js"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/tap-mocha-reporter/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap-parser": {
+      "version": "10.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/tap-parser/-/tap-parser-10.1.0.tgz",
+      "integrity": "sha1-exqsQNvKpHFsC1iVJobq5l0rdK0=",
+      "dev": true,
+      "dependencies": {
+        "events-to-array": "^1.0.1",
+        "minipass": "^3.0.0",
+        "tap-yaml": "^1.0.0"
+      },
+      "bin": {
+        "tap-parser": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/tap-yaml": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/tap-yaml/-/tap-yaml-1.0.0.tgz",
+      "integrity": "sha1-TjFEOlSJ4Fyou7PjbO9xtd7GljU=",
+      "dev": true,
+      "dependencies": {
+        "yaml": "^1.5.0"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/core": {
+      "version": "7.10.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.10.5",
+        "@babel/helper-module-transforms": "^7.10.5",
+        "@babel/helpers": "^7.10.4",
+        "@babel/parser": "^7.10.5",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.5",
+        "@babel/types": "^7.10.5",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/core/node_modules/source-map": {
+      "version": "0.5.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/generator": {
+      "version": "7.10.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.10.5",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/generator/node_modules/source-map": {
+      "version": "0.5.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/helper-builder-react-jsx": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/helper-builder-react-jsx-experimental": {
+      "version": "7.10.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/types": "^7.10.5"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/helper-function-name": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/helper-get-function-arity": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.10.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.10.5"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/helper-module-imports": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/helper-module-transforms": {
+      "version": "7.10.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4",
+        "@babel/helper-simple-access": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.5",
+        "lodash": "^4.17.19"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/helper-plugin-utils": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/@babel/helper-replace-supers": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.10.4",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/helper-simple-access": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/@babel/helpers": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/highlight": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/parser": {
+      "version": "7.10.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-transform-parameters": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/plugin-transform-parameters": {
+      "version": "7.10.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-builder-react-jsx": "^7.10.4",
+        "@babel/helper-builder-react-jsx-experimental": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-jsx": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/template": {
+      "version": "7.10.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/traverse": {
+      "version": "7.10.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.10.5",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.10.4",
+        "@babel/parser": "^7.10.5",
+        "@babel/types": "^7.10.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
+      }
+    },
+    "node_modules/tap/node_modules/@babel/types": {
+      "version": "7.10.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "lodash": "^4.17.19",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "node_modules/tap/node_modules/@types/color-name": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/@types/prop-types": {
+      "version": "15.7.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/@types/react": {
+      "version": "16.9.43",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
+    "node_modules/tap/node_modules/@types/yoga-layout": {
+      "version": "1.9.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/ansi-escapes": {
+      "version": "4.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tap/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/ansicolors": {
+      "version": "0.3.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/append-transform": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/append-transform/-/append-transform-1.0.0.tgz",
+      "integrity": "sha1-BGpSrlgqIovXL1is++KWfGeHWas=",
+      "dev": true,
+      "dependencies": {
+        "default-require-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/arrify": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/auto-bind": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tap/node_modules/caching-transform": {
+      "version": "3.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/caching-transform/-/caching-transform-3.0.2.tgz",
+      "integrity": "sha1-YB1GuR7Kh2h6KB5xzvmXkbDvynA=",
+      "dev": true,
+      "dependencies": {
+        "hasha": "^3.0.0",
+        "make-dir": "^2.0.0",
+        "package-hash": "^3.0.0",
+        "write-file-atomic": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/caching-transform/node_modules/write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/tap/node_modules/caller-callsite": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/caller-path": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "caller-callsite": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/callsites": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/cardinal": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansicolors": "~0.3.2",
+        "redeyed": "~2.1.0"
+      },
+      "bin": {
+        "cdl": "bin/cdl.js"
+      }
+    },
+    "node_modules/tap/node_modules/chalk": {
+      "version": "2.4.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/ci-info": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tap/node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/tap/node_modules/cliui/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/cliui/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+      "dev": true
+    },
+    "node_modules/tap/node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/cliui/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/cliui/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/color-convert": {
+      "version": "1.9.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/tap/node_modules/color-name": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/convert-source-map": {
+      "version": "1.7.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/tap/node_modules/convert-source-map/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/cross-spawn": {
+      "version": "4.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/cross-spawn/-/cross-spawn-4.0.2.tgz",
+      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
+      }
+    },
+    "node_modules/tap/node_modules/cross-spawn/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/which/-/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/tap/node_modules/csstype": {
+      "version": "2.6.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/debug": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/tap/node_modules/default-require-extensions": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+      "dev": true,
+      "dependencies": {
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/tap/node_modules/esprima": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/events-to-array": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/tap/node_modules/find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+      "dev": true,
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/foreground-child": {
+      "version": "1.5.6",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/foreground-child/-/foreground-child-1.5.6.tgz",
+      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^4",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "node_modules/tap/node_modules/gensync": {
+      "version": "1.0.0-beta.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/tap/node_modules/globals": {
+      "version": "11.12.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/has-flag": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/hasha": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/hasha/-/hasha-3.0.0.tgz",
+      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+      "dev": true,
+      "dependencies": {
+        "is-stream": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/import-jsx": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.5.5",
+        "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+        "@babel/plugin-transform-destructuring": "^7.5.0",
+        "@babel/plugin-transform-react-jsx": "^7.3.0",
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/tap/node_modules/ink": {
+      "version": "2.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "arrify": "^2.0.1",
+        "auto-bind": "^4.0.0",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
+        "cli-truncate": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "lodash.throttle": "^4.1.1",
+        "log-update": "^3.0.0",
+        "prop-types": "^15.6.2",
+        "react-reconciler": "^0.24.0",
+        "scheduler": "^0.18.0",
+        "signal-exit": "^3.0.2",
+        "slice-ansi": "^3.0.0",
+        "string-length": "^3.1.0",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoga-layout-prebuilt": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tap/node_modules/ink/node_modules/ansi-styles": {
+      "version": "4.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/tap/node_modules/ink/node_modules/chalk": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/ink/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/tap/node_modules/ink/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/ink/node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/ink/node_modules/supports-color": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/is-ci": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/tap/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tap/node_modules/istanbul-lib-coverage": {
+      "version": "2.0.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/istanbul-lib-hook": {
+      "version": "2.0.7",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+      "integrity": "sha1-yVaV84PU+PYN8fBCUqlVDhW1sTM=",
+      "dev": true,
+      "dependencies": {
+        "append-transform": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/istanbul-lib-instrument": {
+      "version": "3.3.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "istanbul-lib-coverage": "^2.0.5",
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/tap/node_modules/istanbul-lib-processinfo": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/istanbul-lib-processinfo/-/istanbul-lib-processinfo-1.0.0.tgz",
+      "integrity": "sha1-bAtZQR0olzE+oJFl/ZVGSjK+VhA=",
+      "dev": true,
+      "dependencies": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^6.0.5",
+        "istanbul-lib-coverage": "^2.0.3",
+        "rimraf": "^2.6.3",
+        "uuid": "^3.3.2"
+      }
+    },
+    "node_modules/tap/node_modules/istanbul-lib-processinfo/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+      "dev": true,
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/tap/node_modules/istanbul-lib-processinfo/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/which/-/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/tap/node_modules/istanbul-lib-report": {
+      "version": "2.0.8",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "integrity": "sha1-WoETzXRtQ8SInro2qxDn1QybTzM=",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "supports-color": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "6.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/supports-color/-/supports-color-6.1.0.tgz",
+      "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/istanbul-lib-source-maps": {
+      "version": "3.0.6",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "integrity": "sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "rimraf": "^2.6.3",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/istanbul-reports": {
+      "version": "2.2.7",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+      "integrity": "sha1-XZOfYjfXtIOTzAlZ6rQM1P0FaTE=",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/jsesc": {
+      "version": "2.5.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/json5": {
+      "version": "2.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/lodash": {
+      "version": "4.17.19",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/log-update": {
+      "version": "3.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^3.2.0",
+        "cli-cursor": "^2.1.0",
+        "wrap-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tap/node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "3.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/log-update/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/log-update/node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/log-update/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/log-update/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/log-update/node_modules/onetime": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/log-update/node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/log-update/node_modules/string-width": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/log-update/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/loose-envify": {
+      "version": "1.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/tap/node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+      "dev": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/minimist": {
+      "version": "1.2.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/minipass": {
+      "version": "3.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/tap/node_modules/ms": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/nyc": {
+      "version": "14.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/nyc/-/nyc-14.1.1.tgz",
+      "integrity": "sha1-FR1kpqn59ZCKG3MjOTHkoKMHXus=",
+      "dev": true,
+      "dependencies": {
+        "archy": "^1.0.0",
+        "caching-transform": "^3.0.2",
+        "convert-source-map": "^1.6.0",
+        "cp-file": "^6.2.0",
+        "find-cache-dir": "^2.1.0",
+        "find-up": "^3.0.0",
+        "foreground-child": "^1.5.6",
+        "glob": "^7.1.3",
+        "istanbul-lib-coverage": "^2.0.5",
+        "istanbul-lib-hook": "^2.0.7",
+        "istanbul-lib-instrument": "^3.3.0",
+        "istanbul-lib-report": "^2.0.8",
+        "istanbul-lib-source-maps": "^3.0.6",
+        "istanbul-reports": "^2.2.4",
+        "js-yaml": "^3.13.1",
+        "make-dir": "^2.1.0",
+        "merge-source-map": "^1.1.0",
+        "resolve-from": "^4.0.0",
+        "rimraf": "^2.6.3",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^5.2.3",
+        "uuid": "^3.3.2",
+        "yargs": "^13.2.2",
+        "yargs-parser": "^13.0.0"
+      },
+      "bin": {
+        "nyc": "bin/nyc.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/nyc/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/object-assign": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tap/node_modules/onetime": {
+      "version": "5.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/package-hash": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/package-hash/-/package-hash-3.0.0.tgz",
+      "integrity": "sha1-UBg/LTbJ4+Uo6gqGBd/1fOl2+I4=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^3.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/path-parse": {
+      "version": "1.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/prop-types": {
+      "version": "15.7.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "node_modules/tap/node_modules/punycode": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/react-is": {
+      "version": "16.13.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/react-reconciler": {
+      "version": "0.24.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.18.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0"
+      }
+    },
+    "node_modules/tap/node_modules/redeyed": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "esprima": "~4.0.0"
+      }
+    },
+    "node_modules/tap/node_modules/resolve": {
+      "version": "1.17.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tap/node_modules/resolve-from": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/tap/node_modules/scheduler": {
+      "version": "0.18.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "node_modules/tap/node_modules/semver": {
+      "version": "5.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/tap/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tap/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tap/node_modules/signal-exit": {
+      "version": "3.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/tap/node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "4.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/tap/node_modules/slice-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/tap/node_modules/slice-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tap/node_modules/spawn-wrap": {
+      "version": "1.4.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/spawn-wrap/-/spawn-wrap-1.4.3.tgz",
+      "integrity": "sha1-gbdnDhcMyiR9gL9frwz7cTvc+Eg=",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^1.5.6",
+        "mkdirp": "^0.5.0",
+        "os-homedir": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.2",
+        "which": "^1.3.0"
+      }
+    },
+    "node_modules/tap/node_modules/spawn-wrap/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/which/-/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/tap/node_modules/string-length": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "astral-regex": "^1.0.0",
+        "strip-ansi": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/string-length/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/string-length/node_modules/astral-regex": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/string-length/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/string-width": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/supports-color": {
+      "version": "5.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/tap-parser": {
+      "version": "10.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-to-array": "^1.0.1",
+        "minipass": "^3.0.0",
+        "tap-yaml": "^1.0.0"
+      },
+      "bin": {
+        "tap-parser": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/tap/node_modules/tap-yaml": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yaml": "^1.5.0"
+      }
+    },
+    "node_modules/tap/node_modules/test-exclude": {
+      "version": "5.2.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/test-exclude/-/test-exclude-5.2.3.tgz",
+      "integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^4.0.0",
+        "require-main-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/treport": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cardinal": "^2.1.1",
+        "chalk": "^3.0.0",
+        "import-jsx": "^3.1.0",
+        "ink": "^2.6.0",
+        "ms": "^2.1.2",
+        "string-length": "^3.1.0",
+        "tap-parser": "^10.0.1",
+        "unicode-length": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.6"
+      }
+    },
+    "node_modules/tap/node_modules/treport/node_modules/ansi-styles": {
+      "version": "4.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/tap/node_modules/treport/node_modules/chalk": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/treport/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/tap/node_modules/treport/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/treport/node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/treport/node_modules/supports-color": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/type-fest": {
+      "version": "0.11.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tap/node_modules/unicode-length": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.0.0",
+        "strip-ansi": "^3.0.1"
+      }
+    },
+    "node_modules/tap/node_modules/unicode-length/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tap/node_modules/unicode-length/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tap/node_modules/widest-line": {
+      "version": "3.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap/node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/tap/node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/tap/node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/tap/node_modules/yaml": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tap/node_modules/yargs": {
+      "version": "13.3.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      }
+    },
+    "node_modules/tap/node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/tap/node_modules/yargs/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/yargs/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+      "dev": true
+    },
+    "node_modules/tap/node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tap/node_modules/yargs/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/yargs/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tap/node_modules/yoga-layout-prebuilt": {
+      "version": "1.9.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yoga-layout": "1.9.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tape": {
+      "version": "2.3.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/tape/-/tape-2.3.3.tgz",
+      "integrity": "sha1-Lnzgox3wn41oUWZKcYQuDKUFevc=",
+      "dependencies": {
+        "deep-equal": "~0.1.0",
+        "defined": "~0.0.0",
+        "inherits": "~2.0.1",
+        "jsonify": "~0.0.0",
+        "resumer": "~0.0.0",
+        "through": "~2.3.4"
+      },
+      "bin": {
+        "tape": "bin/tape"
+      }
+    },
+    "node_modules/tcompare": {
+      "version": "3.0.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/tcompare/-/tcompare-3.0.4.tgz",
+      "integrity": "sha1-6S69vxrzN1evoHF6rtW7Tv3UGZI=",
+      "dev": true,
+      "dependencies": {
+        "diff-frag": "^1.0.1"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha1-BKhphmHYBepvopO2y55jrARO8V4=",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/trivial-deferred": {
+      "version": "1.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
+      "integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM=",
+      "dev": true
+    },
+    "node_modules/ts-node": {
+      "version": "8.10.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/ts-node/-/ts-node-8.10.2.tgz",
+      "integrity": "sha1-7uA3ZGM7EjTd03+NuewQt17H+40=",
+      "dev": true,
+      "dependencies": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
+      "dev": true,
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "3.9.7",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha1-mNYApevcOPQMsndSLxLcgA6eJfo=",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/unicode-length": {
+      "version": "2.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/unicode-length/-/unicode-length-2.0.2.tgz",
+      "integrity": "sha1-5etMDVI/33vrtZyiYcnKHPcy2pY=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.0.0",
+        "strip-ansi": "^3.0.1"
+      }
+    },
+    "node_modules/unicode-length/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unicode-length/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha1-qnFCYd55PoqCNHp7zJznTobyhgI=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/vlq": {
+      "version": "0.2.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha1-jz5DKM9jsVQMDWfhsneDhviXWyY=",
+      "dev": true
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/which/-/which-2.0.2.tgz",
+      "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+      "dev": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha1-Vr1cWlxwSBzRnFcb05q5ZaXeVug=",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+      "dev": true
+    },
+    "node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "1.10.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha1-O1k63ZRIdgd9TWg/7gEIG9n/8x4=",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yapool": {
+      "version": "1.0.0",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/yapool/-/yapool-1.0.0.tgz",
+      "integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o=",
+      "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha1-HodAGgnXZ8HV6rJqbkwYUYLS61A=",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.10.4",
@@ -656,11 +6298,6 @@
       "requires": {
         "ms": "2.1.2"
       }
-    },
-    "debuglog": {
-      "version": "1.0.1",
-      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/debuglog/-/debuglog-1.0.1.tgz",
-      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
     },
     "decamelize": {
       "version": "1.2.0",
@@ -2370,6 +8007,12 @@
       "integrity": "sha1-M+ujiXeIVYvr/C2wWdwVjsNs67g=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/string-width/-/string-width-4.2.0.tgz",
@@ -2380,12 +8023,6 @@
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "http://npm.paypal.com/artifactory/api/npm/npm-all/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "strip-ansi": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "async": "^2.6.3",
     "caller": "^1.0.1",
     "core-util-is": "^1.0.2",
-    "debuglog": "^1.0.1",
     "minimist": "^1.2.5",
     "shortstop": "^1.0.3",
     "shortstop-handlers": "^1.0.1",


### PR DESCRIPTION
This change swaps the `debuglog` package, which was a backport of the `util.debuglog` function from `v0.11` to `v0.10`, to the native implementation provided by Node v0.11+. We're now operating on v18+ and this package is no longer necessary.