### PR TITLE
chore: remove core-util-is for standard implementations

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,12 +15,11 @@
  \*───────────────────────────────────────────────────────────────────────────*/
 const Path = require('path');
 const caller = require('caller');
-const Thing = require('core-util-is');
 const Factory = require('./lib/factory');
 
 
 module.exports = function confit(options = {}) {
-    if (Thing.isString(options)) {
+    if (typeof options === 'string') {
         options = { basedir: options };
     }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -16,7 +16,13 @@
 'use strict';
 
 const Path = require('path');
-const Thing = require('core-util-is');
+
+/**
+ * Returns `true` if the given object is strictly an `Object` and not a `Function` (even though functions are objects in JavaScript). Otherwise, returns `false`
+ * @param {unknown} val
+ * @returns {boolean}
+ */
+const isObject = (value) => value !== null && typeof value === "object";
 
 
 module.exports = {
@@ -38,7 +44,7 @@ module.exports = {
 
     merge(src, dest) {
         // NOTE: Do not merge arrays and only merge objects into objects. Do not merge special objects created from custom Classes.
-        if (!Thing.isArray(src) && Thing.isObject(src) && Thing.isObject(dest) && Object.getPrototypeOf(src) ===  Object.prototype) {
+        if (!Array.isArray(src) && isObject(src) && isObject(dest) && Object.getPrototypeOf(src) ===  Object.prototype) {
             for (let prop of Object.getOwnPropertyNames(src)) {
                 let descriptor = Object.getOwnPropertyDescriptor(src, prop);
                 descriptor.value = this.merge(descriptor.value, dest[prop]);

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,7 +15,6 @@
  \*───────────────────────────────────────────────────────────────────────────*/
 'use strict';
 
-const Thing = require('core-util-is');
 const Common = require('./common.js');
 
 
@@ -27,7 +26,7 @@ class Config {
     get(key) {
         var obj;
 
-        if (Thing.isString(key) && key.length) {
+        if (typeof key === 'string' && key.length) {
 
             key = key.split(':');
             obj = this._store;
@@ -52,7 +51,7 @@ class Config {
     set(key, value) {
         var obj, prop;
 
-        if (Thing.isString(key) && key.length) {
+        if (typeof key === 'string' && key.length) {
 
             key = key.split(':');
             obj = this._store;

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -18,7 +18,6 @@
 const Path = require('path');
 const shush = require('shush');
 const { debuglog } = require('util');
-const Thing = require('core-util-is');
 const Config = require('./config');
 const Common = require('./common');
 const Handlers = require('./handlers');
@@ -74,7 +73,7 @@ class Factory {
     }
 
     _resolveFile(path) {
-        if (Thing.isString(path)) {
+        if (typeof path === 'string') {
             let file = Common.isAbsolute(path) ? path : Path.join(this.basedir, path);
             return shush(file);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "async": "^2.6.3",
         "caller": "^1.0.1",
-        "core-util-is": "^1.0.2",
         "minimist": "^1.2.5",
         "shortstop": "^1.0.3",
         "shortstop-handlers": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "async": "^2.6.3",
     "caller": "^1.0.1",
-    "core-util-is": "^1.0.2",
     "minimist": "^1.2.5",
     "shortstop": "^1.0.3",
     "shortstop-handlers": "^1.0.1",


### PR DESCRIPTION
This PR removes `core-util-is` which was built to backport Nodejs `v0.11` util functions to `v0.10`. 

Since then, they have been released and deprecated in `v4`. 

I have removed the `core-util-is` dependency and implemented as suggested by Nodejs in the deprecation notes.